### PR TITLE
Switch collision tweak

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -9374,7 +9374,7 @@ const BehaviorScript bhvOnOffButton[] = {
     SET_HOME(),
     BEGIN_LOOP(),
         CALL_NATIVE(bhv_onoffswitch),
-        CALL_NATIVE(load_object_collision_model),
+        //CALL_NATIVE(load_object_collision_model),
     END_LOOP(),
 };
 

--- a/src/game/behaviors/tilting_inverted_pyramid.inc.c
+++ b/src/game/behaviors/tilting_inverted_pyramid.inc.c
@@ -6153,6 +6153,9 @@ void bhv_onoffswitch(void) {
                     o->oAction = 2;
                 }
             }
+
+            // Only load collision when in action state 1
+            load_object_collision_model();
             break;
         case 2: // switch down
             o->header.gfx.scale[1] = approach_f32_symmetric(o->header.gfx.scale[1], 0.1f ,0.1f);

--- a/src/game/behaviors/tilting_inverted_pyramid.inc.c
+++ b/src/game/behaviors/tilting_inverted_pyramid.inc.c
@@ -6168,6 +6168,9 @@ void bhv_onoffswitch(void) {
                     o->oAction = 1;
                 }
             }
+
+            // @todo
+            // Load collision in action state 2 when compatibility calls for it
             break;
     }
 }


### PR DESCRIPTION
Moves collision update for switches from behavior to update function, and only calls it when the switches are in non-pressed state. No bugs from what I can tell, but a comment has been left to indicate where backwards compatibility needs to be implemented for maps from 1.0