### PR TITLE
Add toggle for screenshot help text

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -8,7 +8,7 @@
 //maker text
 #define TXT_RECORDING _("Building path in progress!\n\n[A]: Place waypoint\n[B]: Undo\nSTART: Confirm")
 
-#define TXT_FREECAM _("Analog Stick: Look around\n[C] ^ / |: Move forward / backward\n[C] < / >: Move sideways\nL / [R]: Zoom\nSTART: Take screenshot\n[B]: Exit")
+#define TXT_FREECAM _("Analog Stick: Look around\n[C] ^ / |: Move forward / backward\n[C] < / >: Move sideways\nL / [R]: Zoom\n[Z]: Toggle Help\nSTART: Take screenshot\n[B]: Exit")
 
 #define TXT_MM_PAGE _("Page: 0/0")
 

--- a/src/game/cursed_mirror_maker.c
+++ b/src/game/cursed_mirror_maker.c
@@ -3252,6 +3252,7 @@ void freecam_camera_main(void) {
             cmm_prepare_level_screenshot = FALSE;
             vec3f_copy(cmm_camera_pos,cmm_camera_pos_prev);
             generate_object_preview();
+            cmm_freecam_help = TRUE;
         }
         return;
     }

--- a/src/game/cursed_mirror_maker.c
+++ b/src/game/cursed_mirror_maker.c
@@ -3219,6 +3219,7 @@ extern s16 cmm_menu_end_timer;
 s16 cmm_freecam_pitch;
 s16 cmm_freecam_yaw;
 u8 cmm_freecam_snap = FALSE;
+u8 cmm_freecam_help = TRUE;
 u8 cmm_freecam_snap_timer = 0;
 
 void freecam_camera_init(void) {
@@ -3304,6 +3305,10 @@ void freecam_camera_main(void) {
         if (cmm_camera_fov > 100.0f) {
             cmm_camera_fov = 100.0f;
         }
+    }
+
+    if (gPlayer1Controller->buttonPressed & Z_TRIG) {
+        cmm_freecam_help = !cmm_freecam_help;
     }
 
     if (gPlayer1Controller->buttonPressed & START_BUTTON) {

--- a/src/game/cursed_mirror_maker_menu.inc.c
+++ b/src/game/cursed_mirror_maker_menu.inc.c
@@ -1221,7 +1221,7 @@ void draw_cmm_menu(void) {
             break;
 
         case CMM_MAKE_SCREENSHOT:
-            if (cmm_freecam_snap) {
+            if (cmm_freecam_snap || !cmm_freecam_help) {
                 return;
             }
             print_maker_string(20,210,cmm_txt_freecam,TRUE);


### PR DESCRIPTION
Minor tweak, just lets you toggle the help text by pressing the Z trigger. Mainly useful for getting external screenshots of your level without text polluting the screen.