### PR TITLE
Fix reloading levels after selecting "Save & Quit" option

### DIFF
--- a/src/game/cursed_mirror_maker.c
+++ b/src/game/cursed_mirror_maker.c
@@ -2798,9 +2798,10 @@ void save_level(void) {
     bcopy(&cmm_toolbar, &cmm_save.toolbar, sizeof(cmm_save.toolbar));
     bcopy(&cmm_toolbar_params, &cmm_save.toolbar_params, sizeof(cmm_save.toolbar_params));
 
-    f_chdir(cmm_level_dir_name);
+    TCHAR path[256];
+    create_level_file_path(path, cmm_file_name, NULL);
     UINT bytes_written;
-    f_open(&cmm_file,cmm_file_name, FA_READ | FA_WRITE | FA_CREATE_ALWAYS);
+    f_open(&cmm_file,path, FA_READ | FA_WRITE | FA_CREATE_ALWAYS);
     //write header
     f_write(&cmm_file,&cmm_save,sizeof(cmm_save),&bytes_written);
     //write tiles
@@ -2809,8 +2810,6 @@ void save_level(void) {
     f_write(&cmm_file,&cmm_object_data,(sizeof(cmm_object_data[0])*cmm_object_count),&bytes_written);
 
     f_close(&cmm_file);
-
-    f_chdir("..");
 }
 
 void load_level(void) {
@@ -2821,12 +2820,13 @@ void load_level(void) {
     bzero(&cmm_save, sizeof(cmm_save));
     bzero(&cmm_grid_data, sizeof(cmm_grid_data));
 
-    f_chdir(cmm_level_dir_name); //chdir exits after the ifelse statement
-    FRESULT code = f_stat(cmm_file_name,&cmm_file_info);
+    TCHAR path[256];
+    create_level_file_path(path, cmm_file_name, NULL);
+    FRESULT code = f_stat(path,&cmm_file_info);
     if (code == FR_OK) {
         UINT bytes_read;
         //file exists, load it
-        f_open(&cmm_file,cmm_file_name, FA_READ | FA_WRITE);
+        f_open(&cmm_file,path, FA_READ | FA_WRITE);
         //read header
         f_read(&cmm_file,&cmm_save,sizeof(cmm_save),&bytes_read);
         //read tiles
@@ -2886,7 +2886,6 @@ void load_level(void) {
 
         bcopy(&cmm_default_custom,&cmm_save.custom_theme,sizeof(struct cmm_custom_theme));
     }
-    f_chdir("..");
 
     cmm_tile_count = cmm_save.tile_count;
     cmm_object_count = cmm_save.object_count;

--- a/src/game/cursed_mirror_maker_menu.inc.c
+++ b/src/game/cursed_mirror_maker_menu.inc.c
@@ -2283,9 +2283,7 @@ s32 cmm_main_menu(void) {
                 }
                 cmm_file_name[i] = '\0'; // add null terminator
 
-                f_chdir(cmm_level_dir_name);
-                struct cmm_level_save_header * level_info = get_level_info_from_filename(&cmm_file_name);
-                f_chdir("..");
+                struct cmm_level_save_header * level_info = get_level_info_from_filename(cmm_file_name);
                 cmm_lopt_game = level_info->game;
                 cmm_mm_selected_level = cmm_menu_index;
                 if (cmm_level_action == CMM_LA_BUILD) cmm_tip_timer = 60;

--- a/src/game/game_init.h
+++ b/src/game/game_init.h
@@ -103,10 +103,11 @@ extern u8 cmm_level_entry_version[MAX_FILES];
 extern FRESULT mount_success;
 extern FRESULT global_code;
 extern u8 cmm_level_entry_count;
-extern TCHAR cmm_level_dir_name[];
-extern TCHAR cmm_hack_dir_name[];
+extern TCHAR *cmm_level_dir_name;
+extern TCHAR *cmm_hack_dir_name;
 extern struct cmm_sram_config cmm_sram_configuration;
 
+void create_level_file_path(TCHAR * buffer, TCHAR * filename, TCHAR * suffix);
 struct cmm_level_save_header * get_level_info_from_filename(char * filename);
 void load_level_files_from_sd_card(void);
 u8 level_file_exists(char * filename);

--- a/src/libcart/ff/ffconf.h
+++ b/src/libcart/ff/ffconf.h
@@ -113,7 +113,7 @@
 */
 
 
-#define FF_USE_LFN		1
+#define FF_USE_LFN		2
 #define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /
@@ -153,7 +153,7 @@
 /  on character encoding. When LFN is not enabled, these options have no effect. */
 
 
-#define FF_FS_RPATH		1
+#define FF_FS_RPATH		0
 /* This option configures support for relative path.
 /
 /   0: Disable relative path and remove related functions.

--- a/src/libcart/ff/ffconf.h
+++ b/src/libcart/ff/ffconf.h
@@ -84,7 +84,7 @@
 / Locale and Namespace Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_CODE_PAGE	932
+#define FF_CODE_PAGE	437
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect code page setting can cause a file open failure.
 /


### PR DESCRIPTION
This PR fixes the issue present on the flashcarts that prevented reloading level list after exiting level edit. It removes every usage of the `f_chdir` function. Instead, full paths are used. There is no prevention measures against path (level dir + level name + file extension) being longer than 255 characters. Don't know if level name is capped elsewhere but there's still room for improvement that I'll leave for someone other than me.

Additionally I changed the code page because there's no reason to keep japanese conversion table that's several times bigger than standard US ASCII one.