### PR TITLE
Fix label-statement compiler error

### DIFF
--- a/src/game/mb64.c
+++ b/src/game/mb64.c
@@ -3891,6 +3891,7 @@ void sb_loop(void) {
                 switch(mb64_toolbar_index) {
                     case 7: // save and test
                         // Tile Check
+                        ; // prevents error "a label can only be part of a statement and a declaration is not a statement"
                         u32 type = get_grid_tile(mb64_cursor_pos)->type;
                         if (type != TILE_TYPE_EMPTY && type != TILE_TYPE_WATER) {
                             u32 tileFlags = get_tile_occupy_flags(type);


### PR DESCRIPTION
Adds a blank statement to fix the compiler error "a label can only be part of a statement and a declaration is not a statement". (See https://stackoverflow.com/q/18496282/3357935)